### PR TITLE
Specify Python version in conda environment creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Also, We recommend using the pytorch>=2.0, cuda>=11.8. But lower version of pyto
 ***Create and activate a new conda environment***
 
 ```bash
-conda create -n vmamba
+conda create -n vmamba python=3.8 -y
 conda activate vmamba
 ```
 


### PR DESCRIPTION
Hello,

I was having a hard time getting training to work, until I realized the documentation for MMDetection specifies Python version 3.8 in the [GETTING STARTED](https://mmdetection.readthedocs.io/en/latest/get_started.html) guide.

This repo could very easily echo this in the README, as that was what finally worked for me.